### PR TITLE
Add endpoint to fetch bookings for agent-owned cars

### DIFF
--- a/controllers/adminCarsController.js
+++ b/controllers/adminCarsController.js
@@ -1,4 +1,5 @@
 const Car = require('../models/Car');
+const Booking = require('../models/Booking');
 
 // GET: Get all pending cars
 exports.getPendingCars = async (req, res) => {
@@ -56,5 +57,39 @@ exports.getRejectedCars = async (req, res) => {
     res.status(200).json(rejectedCars);
   } catch (err) {
     res.status(500).json({ error: 'Server error' });
+  }
+};
+
+
+// Get all car bookings with full nested data
+exports.getCarBookings = async (req, res) => {
+  try {
+    const bookings = await Booking.find()
+      .populate({
+        path: 'clientId',
+        populate: {
+          path: 'user_id',
+          model: 'User',
+          select: 'email role'
+        },
+        select: 'first_name last_name phone_number location'
+      })
+      .populate({
+        path: 'carId',
+        select: 'brand model year licensePlate type transmission fuel_type seats color rentalRatePerDay rentalRatePerHour'
+      })
+      .populate({
+        path: 'agent',
+        populate: {
+          path: 'user_id',
+          model: 'User',
+          select: 'email role'
+        },
+        select: 'company_name phone_number location'
+      });
+
+    res.status(200).json(bookings);
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to fetch bookings', error: err.message });
   }
 };

--- a/routes/adminCarsRoutes.js
+++ b/routes/adminCarsRoutes.js
@@ -28,4 +28,7 @@ router.put('/:id/approve', adminCarsController.approveCar);
 router.put('/:id/reject', adminCarsController.rejectCar);
 
 
+// Get all car bookings
+router.get('/booking', adminCarsController.getCarBookings);
+
 module.exports = router;

--- a/routes/agentCarsRoutes.js
+++ b/routes/agentCarsRoutes.js
@@ -10,6 +10,8 @@ const ensureApprovedAgent = require('../middleware/ensureApprovedAgent');
 router.use(authorizeUser);
 router.use(ensureApprovedAgent);
 
+router.get('/bookings', agentCarsController.getBookingsForAgentCars);
+
 router.get('/', agentCarsController.getAllCars);
 router.get('/:id', agentCarsController.getCarById);
 router.post('/', upload.fields([
@@ -20,6 +22,10 @@ router.put('/:id', upload.fields([
     { name: 'carPhotos', maxCount: 5 },
     { name: 'documents', maxCount: 5 }
 ]), agentCarsController.updateCar);
+
+
 router.delete('/:id', agentCarsController.deleteCar);
+
+
 
 module.exports = router;


### PR DESCRIPTION
This PR introduces a new API endpoint that allows agents to retrieve only the bookings associated with the cars they own. This ensures agents cannot access bookings for vehicles that are not theirs.

Added GET /api/agent/cars/bookings route to fetch all bookings related to the agent's cars.

Populates car and client information for better context in response.

Only authenticated and approved agents can access this endpoint using the existing authorizeUser and ensureApprovedAgent middleware.

Implementation:
Queried the Car model to get all car IDs owned by the agent.

Queried the Booking model with those car IDs.

Populated:

carId with basic car info (brand, model, licensePlate)

clientId with client profile info and nested user_id.email